### PR TITLE
feat: separate embed model impl, add payload field to Qdrant

### DIFF
--- a/severn/src/models.rs
+++ b/severn/src/models.rs
@@ -7,8 +7,9 @@ use async_openai::{
     types::{
         ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageArgs,
         ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs,
+        CreateEmbeddingRequest, EmbeddingInput,
     },
-    Client,
+    Client, Embeddings,
 };
 use async_trait::async_trait;
 
@@ -29,6 +30,37 @@ impl OpenAI {
 
         Ok(Self { client })
     }
+
+    pub fn from_env_with_org_id(org_id: &str) -> Result<Self> {
+        let api_key = std::env::var("OPENAI_API_KEY")?;
+        let config = OpenAIConfig::new()
+            .with_api_key(api_key)
+            .with_org_id(org_id);
+
+        let client = Client::with_config(config);
+
+        Ok(Self { client })
+    }
+
+    pub fn from_str(api_key: &str) -> Result<Self> {
+        let config = OpenAIConfig::new()
+            .with_api_key(api_key)
+            .with_org_id("severn");
+
+        let client = Client::with_config(config);
+
+        Ok(Self { client })
+    }
+
+    pub fn from_str_with_org_id(api_key: &str, org_id: &str) -> Result<Self> {
+        let config = OpenAIConfig::new()
+            .with_api_key(api_key)
+            .with_org_id(org_id);
+
+        let client = Client::with_config(config);
+
+        Ok(Self { client })
+    }
 }
 
 #[async_trait]
@@ -39,6 +71,12 @@ pub trait PromptModel {
         data: String,
         agent: &Arc<dyn Agent>,
     ) -> Result<String, Error>;
+}
+
+#[async_trait]
+pub trait EmbedModel {
+    async fn embed_file(&self, chunked_contents: Vec<String>) -> anyhow::Result<Vec<Vec<f32>>>;
+    async fn embed_sentence(&self, prompt: &str) -> anyhow::Result<Vec<f32>>;
 }
 
 #[async_trait]
@@ -91,5 +129,53 @@ impl PromptModel for OpenAI {
         println!("Retrieved result from prompt: {res}");
 
         Ok(res)
+    }
+}
+
+#[async_trait]
+impl EmbedModel for OpenAI {
+    async fn embed_file(&self, chunked_contents: Vec<String>) -> anyhow::Result<Vec<Vec<f32>>> {
+        let embedding_request = CreateEmbeddingRequest {
+            model: "text-embedding-ada-002".to_string(),
+            input: EmbeddingInput::StringArray(chunked_contents.to_owned()),
+            encoding_format: None, // defaults to f32
+            user: None,
+            dimensions: Some(1536),
+        };
+
+        let embeddings = Embeddings::new(&self.client)
+            .create(embedding_request)
+            .await?;
+
+        if embeddings.data.is_empty() {
+            return Err(anyhow::anyhow!(
+                "There were no embeddings returned by OpenAI!"
+            ));
+        }
+
+        Ok(embeddings.data.into_iter().map(|x| x.embedding).collect())
+    }
+
+    async fn embed_sentence(&self, prompt: &str) -> anyhow::Result<Vec<f32>> {
+        let embedding_request = CreateEmbeddingRequest {
+            model: "text-embedding-ada-002".to_string(),
+            input: EmbeddingInput::String(prompt.to_owned()),
+            encoding_format: None, // defaults to f32
+            user: None,
+            dimensions: Some(1536),
+        };
+
+        let embeddings = Embeddings::new(&self.client)
+            .create(embedding_request)
+            .await?;
+
+        let embedding = embeddings.data.into_iter().next();
+
+        match embedding {
+            Some(res) => Ok(res.embedding),
+            None => Err(anyhow::anyhow!(
+                "There were no embeddings returned by OpenAI!"
+            )),
+        }
     }
 }

--- a/severn/src/models.rs
+++ b/severn/src/models.rs
@@ -42,7 +42,7 @@ impl OpenAI {
         Ok(Self { client })
     }
 
-    pub fn from_str(api_key: &str) -> Result<Self> {
+    pub fn from_api_key(api_key: &str) -> Result<Self> {
         let config = OpenAIConfig::new()
             .with_api_key(api_key)
             .with_org_id("severn");
@@ -52,7 +52,7 @@ impl OpenAI {
         Ok(Self { client })
     }
 
-    pub fn from_str_with_org_id(api_key: &str, org_id: &str) -> Result<Self> {
+    pub fn from_api_key_with_org_id(api_key: &str, org_id: &str) -> Result<Self> {
         let config = OpenAIConfig::new()
             .with_api_key(api_key)
             .with_org_id(org_id);


### PR DESCRIPTION
Separates the embedding model out into its own trait so the `Qdrant` struct is not reliant on holding an LLM struct.